### PR TITLE
stdout: Make EOL `\r\n` instead of `\n\r`

### DIFF
--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -14,18 +14,18 @@ impl<'p, T> Write for Stdout<'p, T>
 {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         for byte in s.as_bytes() {
-            let res = block!(self.0.write(*byte));
-
-            if res.is_err() {
-                return Err(::core::fmt::Error);
-            }
-
             if *byte == b'\n' {
                 let res = block!(self.0.write(b'\r'));
 
                 if res.is_err() {
                     return Err(::core::fmt::Error);
                 }
+            }
+
+            let res = block!(self.0.write(*byte));
+
+            if res.is_err() {
+                return Err(::core::fmt::Error);
             }
         }
         Ok(())


### PR DESCRIPTION
The expected order seems to be \r\n (13 10), not the other way around.
(had a fight with the WIFI chip about this)
