### PR TITLE
UART serial

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -9,6 +9,7 @@ use crate::time::Hertz;
 #[derive(Clone, Copy)]
 pub struct Clocks {
     cpu: Hertz,
+    apb0: Hertz,
 }
 
 impl Clocks {
@@ -24,12 +25,18 @@ impl Clocks {
         cpu_freq: 390000000
 */
         Self {
-            cpu: Hertz(403_000_000)
+            cpu: Hertz(403_000_000),
+            apb0: Hertz(195_000_000),
         }
     }
 
     /// Returns CPU frequency
     pub fn cpu(&self) -> Hertz {
         Hertz(self.cpu.0)
+    }
+
+    /// Returns APB0 frequency
+    pub fn apb0(&self) -> Hertz {
+        self.apb0
     }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -7,14 +7,18 @@
 //! * [`UART3`](crate::pac::UART3)
 
 use core::marker::PhantomData;
+use core::ops::Deref;
 
 use embedded_hal::serial;
 use nb;
 use void::Void;
 
-use crate::pac::UARTHS;
+use crate::pac::{UARTHS,uart1,UART1,UART2,UART3};
 use crate::clock::Clocks;
 use crate::time::Bps;
+
+const UART_RECEIVE_FIFO_1: u32 = 0;
+const UART_SEND_FIFO_8: u32 = 3;
 
 /// Extension trait that constrains UART peripherals
 pub trait SerialExt: Sized {
@@ -24,7 +28,28 @@ pub trait SerialExt: Sized {
 
 impl SerialExt for UARTHS {
     fn constrain(self, baud_rate: Bps, clocks: &Clocks) -> Serial<UARTHS> {
-        Serial::new(self, baud_rate, clocks)
+        Serial::<UARTHS>::new(self, baud_rate, clocks)
+    }
+}
+
+/// Trait to be able to generalize over UART1/UART2/UART3
+pub trait UartX: Deref<Target = uart1::RegisterBlock> {
+    /// Return pointer to register block
+    fn ptr() -> *const uart1::RegisterBlock;
+}
+impl UartX for UART1 {
+    fn ptr() -> *const uart1::RegisterBlock { UART1::ptr() }
+}
+impl UartX for UART2 {
+    fn ptr() -> *const uart1::RegisterBlock { UART2::ptr() }
+}
+impl UartX for UART3 {
+    fn ptr() -> *const uart1::RegisterBlock { UART3::ptr() }
+}
+
+impl<UART: UartX> SerialExt for UART {
+    fn constrain(self, baud_rate: Bps, clocks: &Clocks) -> Serial<UART> {
+        Serial::<UART>::new(self, baud_rate, clocks)
     }
 }
 
@@ -141,5 +166,85 @@ impl serial::Write<u8> for Tx<UARTHS> {
         } else {
             Ok(())
         }
+    }
+}
+
+
+impl<UART: UartX> Serial<UART> {
+    /// Configures a UART peripheral to provide serial communication
+    pub fn new(uart: UART, baud_rate: Bps, clocks: &Clocks) -> Self {
+        // Hardcode these for now:
+        let data_width = 8; // 8 data bits
+        let stopbit_val = 0; // 1 stop bit
+        let parity_val = 0; // No parity
+        // Note: need to make sure that UARTx clock is enabled through sysctl before here
+        let divisor = clocks.apb0().0 / baud_rate.0;
+        let dlh = ((divisor >> 12) & 0xff) as u8;
+        let dll = ((divisor >> 4) & 0xff) as u8;
+        let dlf = (divisor & 0xf) as u8;
+        unsafe {
+            // Set Divisor Latch Access Bit (enables DLL DLH) to set baudrate
+            uart.lcr.write(|w| w.bits(1 << 7));
+            uart.dlh_ier.write(|w| w.bits(dlh.into()));
+            uart.rbr_dll_thr.write(|w| w.bits(dll.into()));
+            uart.dlf.write(|w| w.bits(dlf.into()));
+            // Clear Divisor Latch Access Bit after setting baudrate
+            uart.lcr.write(|w| w.bits((data_width - 5) | (stopbit_val << 2) | (parity_val << 3)));
+            // Write IER
+            uart.dlh_ier.write(|w| w.bits(0x80)); /* THRE */
+            // Write FCT
+            uart.fcr_iir.write(|w| w.bits(UART_RECEIVE_FIFO_1 << 6 | UART_SEND_FIFO_8 << 4 | 0x1 << 3 | 0x1));
+        }
+
+        Serial { uart }
+    }
+
+    /// Starts listening for an interrupt event
+    pub fn listen(self) -> Self {
+        self
+    }
+
+    /// Stops listening for an interrupt event
+    pub fn unlisten(self) -> Self {
+        self
+    }
+}
+
+impl<UART: UartX> serial::Read<u8> for Rx<UART> {
+    type Error = Void;
+
+    fn read(&mut self) -> nb::Result<u8, Void> {
+        // NOTE(unsafe) atomic read with no side effects
+        let lsr = unsafe { (*UART::ptr()).lsr.read() };
+
+        if (lsr.bits() & (1<<0)) == 0 { // Data Ready bit
+            Err(::nb::Error::WouldBlock)
+        } else {
+            let rbr = unsafe { (*UART::ptr()).rbr_dll_thr.read() };
+            Ok((rbr.bits() & 0xff) as u8)
+        }
+    }
+}
+
+impl<UART: UartX> serial::Write<u8> for Tx<UART> {
+    type Error = Void;
+
+    fn write(&mut self, byte: u8) -> nb::Result<(), Void> {
+        // NOTE(unsafe) atomic read with no side effects
+        let lsr = unsafe { (*UART::ptr()).lsr.read() };
+
+        if (lsr.bits() & (1<<5)) != 0 { // Transmit Holding Register Empty bit
+            Err(::nb::Error::WouldBlock)
+        } else {
+            unsafe {
+                (*UART::ptr()).rbr_dll_thr.write(|w| w.bits(byte.into()));
+            }
+            Ok(())
+        }
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Void> {
+        // TODO
+        Ok(())
     }
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -33,19 +33,10 @@ impl SerialExt for UARTHS {
 }
 
 /// Trait to be able to generalize over UART1/UART2/UART3
-pub trait UartX: Deref<Target = uart1::RegisterBlock> {
-    /// Return pointer to register block
-    fn ptr() -> *const uart1::RegisterBlock;
-}
-impl UartX for UART1 {
-    fn ptr() -> *const uart1::RegisterBlock { UART1::ptr() }
-}
-impl UartX for UART2 {
-    fn ptr() -> *const uart1::RegisterBlock { UART2::ptr() }
-}
-impl UartX for UART3 {
-    fn ptr() -> *const uart1::RegisterBlock { UART3::ptr() }
-}
+pub trait UartX: Deref<Target = uart1::RegisterBlock> { }
+impl UartX for UART1 { }
+impl UartX for UART2 { }
+impl UartX for UART3 { }
 
 impl<UART: UartX> SerialExt for UART {
     fn constrain(self, baud_rate: Bps, clocks: &Clocks) -> Serial<UART> {


### PR DESCRIPTION
Adds support for UART1 to `serial`.

This works, but there's several TODOs:

- ~~My rust knowledge does not extend to how to make the definition generic to UART2/3. The devices are exactly the same but the types are different and do not share a trait.~~ [SOLVED]

- Bit definitions should be in `pac`, however, I do not know how to do this for wacky registers that have completely different meaning based on context, such as `rbr_dll_thr`.

- ~~There's currently no functionality in k210-hal to enable or set clocks. I have an implementation of the [Kendryte SDK's sysctl in rust](https://github.com/laanwj/k210-sdk-stuff/blob/master/rust/k210-shared/src/soc/sysctl.rs#L277) which could be integrated into clocks at some point.~~ (doesn't need to be solved here, I guess)