### PR TITLE
serial: join shouldn't take self

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -49,7 +49,7 @@ impl<UART, PINS> Serial<UART, PINS> {
 
     /// Forms `Serial` abstraction from a transmitter and a
     /// receiver half
-    pub fn join(self, tx: Tx<UART, PINS>, _rx: Rx<UART, PINS>) -> Self {
+    pub fn join(tx: Tx<UART, PINS>, _rx: Rx<UART, PINS>) -> Self {
         Serial { uart: tx.uart, pins: tx.pins }
     }
 


### PR DESCRIPTION
`self` is already consumed while splitting, there's no way to use this method like this