### PR TITLE
bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "k210-hal"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The RISC-V Team <risc-v@teams.rust-embedded.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL for K210 SoC"
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 embedded-hal = { version = "0.2.1", features = ["unproven"] }
 nb = "0.1.1"
-k210-pac = { version = "0.1.0", features = ["rt"] }
+k210-pac = { version = "0.2.0", features = ["rt"] }


### PR DESCRIPTION
This bumps the version of the library, as well as that of the ` k210-pac` dependency to 0.2.0. I think this is required to keep the different k210 packages in sync.