### PR TITLE
Add basic DVP support

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -12,6 +12,7 @@ pub struct Clocks {
     pub(crate) aclk: Hertz,
     pub(crate) apb0: Hertz,
     pub(crate) apb1: Hertz,
+    pub(crate) apb2: Hertz,
 }
 
 impl Clocks {
@@ -30,6 +31,7 @@ impl Clocks {
             aclk: Hertz(390_000_000),
             apb0: Hertz(195_000_000),
             apb1: Hertz(195_000_000),
+            apb2: Hertz(195_000_000),
         }
     }
 
@@ -46,5 +48,10 @@ impl Clocks {
     /// Returns APB1 frequency
     pub fn apb1(&self) -> Hertz {
         self.apb1
+    }
+
+    /// Returns APB2 frequency
+    pub fn apb2(&self) -> Hertz {
+        self.apb2
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,6 +1,6 @@
 //! Clock configuration
 //use crate::pac::PRCI;
-use crate::sysctl::ACLK;
+// use crate::sysctl::ACLK;
 use crate::time::Hertz;
 
 /// Frozen clock frequencies
@@ -11,6 +11,7 @@ use crate::time::Hertz;
 pub struct Clocks {
     pub(crate) aclk: Hertz,
     pub(crate) apb0: Hertz,
+    pub(crate) apb1: Hertz,
 }
 
 impl Clocks {
@@ -28,6 +29,7 @@ impl Clocks {
         Self {
             aclk: Hertz(390_000_000),
             apb0: Hertz(195_000_000),
+            apb1: Hertz(195_000_000),
         }
     }
 
@@ -39,5 +41,10 @@ impl Clocks {
     /// Returns APB0 frequency
     pub fn apb0(&self) -> Hertz {
         self.apb0
+    }
+
+    /// Returns APB1 frequency
+    pub fn apb1(&self) -> Hertz {
+        self.apb1
     }
 }

--- a/src/dvp.rs
+++ b/src/dvp.rs
@@ -1,0 +1,114 @@
+use crate::clock::Clocks;
+use crate::sysctl;
+use crate::time::Hertz;
+use k210_pac as pac;
+
+pub trait DvpExt: Sized {
+    fn constrain(self) -> Dvp;
+}
+
+impl DvpExt for pac::DVP {
+    fn constrain(self) -> Dvp {
+        Dvp { dvp: self }
+    }
+}
+
+pub struct Dvp {
+    pub dvp: pac::DVP,
+}
+
+impl Dvp {
+    pub fn sccb_clk_init(&self) {
+        unsafe {
+            self.dvp
+                .sccb_cfg
+                .modify(|_, w| w.scl_lcnt().bits(255).scl_hcnt().bits(255))
+        }
+    }
+
+    pub fn sccb_clk_set_rate(&self, clk_rate: Hertz, clock: &Clocks) -> Hertz {
+        let sccb_freq = clock.apb1();
+        let period_clk_cnt = (sccb_freq.0 / clk_rate.0 / 2).max(0).min(255) as u8;
+        unsafe {
+            self.dvp.sccb_cfg.modify(|_, w| {
+                w.scl_lcnt()
+                    .bits(period_clk_cnt)
+                    .scl_hcnt()
+                    .bits(period_clk_cnt)
+            })
+        }
+        return Hertz(clock.cpu().0 / period_clk_cnt as u32 / 2);
+    }
+
+    fn sccb_start_transfer(&self) {
+        while self.dvp.sts.read().sccb_en().bit() {
+            // IDLE
+        }
+        self.dvp
+            .sts
+            .write(|w| w.sccb_en().set_bit().sccb_en_we().set_bit());
+        while self.dvp.sts.read().sccb_en().bit() {
+            // IDLE
+        }
+    }
+
+    pub fn sccb_send_data(&self, dev_addr: u8, reg_addr: u8, reg_data: u8) {
+        use pac::dvp::sccb_cfg::BYTE_NUM_A::*;
+        unsafe {
+            self.dvp.sccb_cfg.modify(|_, w| w.byte_num().variant(NUM3));
+            self.dvp.sccb_ctl.write(|w| {
+                w.device_address()
+                    .bits(dev_addr | 1)
+                    .reg_address()
+                    .bits(reg_addr)
+                    .wdata_byte0()
+                    .bits(reg_data)
+            })
+        }
+        self.sccb_start_transfer();
+    }
+
+    pub fn sccb_receive_data(&self, dev_addr: u8, reg_addr: u8) -> u8 {
+        use pac::dvp::sccb_cfg::BYTE_NUM_A::*;
+        unsafe {
+            self.dvp.sccb_cfg.modify(|_, w| w.byte_num().variant(NUM2));
+            self.dvp.sccb_ctl.write(|w| {
+                w.device_address()
+                    .bits(dev_addr | 1)
+                    .reg_address()
+                    .bits(reg_addr as u8)
+            });
+        }
+        self.sccb_start_transfer();
+        unsafe {
+            self.dvp
+                .sccb_ctl
+                .write(|w| w.device_address().bits(dev_addr));
+        }
+        self.sccb_start_transfer();
+        self.dvp.sccb_cfg.read().rdata().bits()
+    }
+
+    pub fn reset(&self) {
+        self.dvp.cmos_cfg.modify(|_, w| w.power_down().set_bit());
+        self.dvp.cmos_cfg.modify(|_, w| w.power_down().clear_bit());
+        self.dvp.cmos_cfg.modify(|_, w| w.reset().clear_bit());
+        self.dvp.cmos_cfg.modify(|_, w| w.reset().set_bit());
+    }
+
+    pub fn init(&self) {
+        // Consider borrowing i.s.o. using global instance of sysctl?
+        sysctl::clk_en_peri().modify(|_, w| w.dvp_clk_en().set_bit());
+        sysctl::peri_reset().modify(|_, w| w.dvp_reset().set_bit());
+        sysctl::peri_reset().modify(|_, w| w.dvp_reset().clear_bit());
+
+        unsafe {
+            self.dvp
+                .cmos_cfg
+                .modify(|_, w| w.clk_div().bits(3).clk_enable().set_bit());
+        }
+
+        self.sccb_clk_init();
+        self.reset();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,29 +13,30 @@ pub mod cache;
 pub mod clint;
 pub mod clock;
 pub mod dmac;
+pub mod dvp;
 pub mod fft;
 pub mod fpioa;
 pub mod gpio;
 pub mod gpiohs;
 pub mod plic;
 pub mod serial;
-pub mod spi;
 pub mod sha256;
+pub mod spi;
 pub mod stdout;
 pub mod sysctl;
 pub mod time;
 
 /// Prelude
 pub mod prelude {
-    pub use embedded_hal::prelude::*;
-    pub use crate::serial::SerialExt as _k210_hal_serial_SerialExt;
-    pub use crate::stdout::Write as _k210_hal_stdout_Write;
-    pub use crate::time::U32Ext as _k210_hal_time_U32Ext;
     pub use crate::fpioa::FpioaExt as _k210_hal_fpioa_FpioaExt;
-    pub use crate::sysctl::SysctlExt as _k210_hal_sysctl_SysctlExt;
     pub use crate::gpio::GpioExt as _k210_hal_gpio_GpioExt;
     pub use crate::gpiohs::GpiohsExt as _k210_hal_gpiohs_GpiohsExt;
     pub use crate::plic::PlicExt as _k210_hal_plic_PlicExt;
+    pub use crate::serial::SerialExt as _k210_hal_serial_SerialExt;
+    pub use crate::stdout::Write as _k210_hal_stdout_Write;
+    pub use crate::sysctl::SysctlExt as _k210_hal_sysctl_SysctlExt;
+    pub use crate::time::U32Ext as _k210_hal_time_U32Ext;
+    pub use embedded_hal::prelude::*;
 }
 
 mod bit_utils {


### PR DESCRIPTION
### Changes Made
- Implemented a APB1 and APB2 clock controls 
- Added `APB1` and `APB2` field to `Clocks` struct 
- Added basic SCCB operation eg. send/receive data
- Added image control function of DVP (referring to C library)

### Purpose
- I was going to use this crate for interfacing my board with OV2640 using DVP, therefore this PR.

### Readiness
- Not going to put any further commit to this PR, therefore it is **ready to merge** after it has been officially reviewed and accepted.

_I appreciate any feedbacks :eyes:_
